### PR TITLE
Fix connection to elasticsearch with empty credentials

### DIFF
--- a/client/elasticsearch.js
+++ b/client/elasticsearch.js
@@ -7,8 +7,8 @@ const error = debug('error')
 const ES_INDEX_NAME = process.env.ES_INDEX_NAME || 'addressr'
 export const ELASTIC_PORT = Number.parseInt(process.env.ELASTIC_PORT || '9200')
 const ELASTIC_HOST = process.env.ELASTIC_HOST || '127.0.0.1'
-const ELASTIC_USERNAME = process.env.ELASTIC_USERNAME || undefined
-const ELASTIC_PASSWORD = process.env.ELASTIC_PASSWORD || undefined
+const ELASTIC_USERNAME = process.env.ELASTIC_USERNAME || ''
+const ELASTIC_PASSWORD = process.env.ELASTIC_PASSWORD || ''
 const ELASTIC_PROTOCOL = process.env.ELASTIC_PROTOCOL || 'http'
 
 export async function dropIndex (esClient) {


### PR DESCRIPTION
Found a small bug with the latest update. The problem is that when Elasticsearch doesn't have a username/password it's impossible to connect to ES.

Due to "interesting" string interpolation logic of `undefined` in JS, the following code generates a wrong connection string
https://github.com/mountain-pass/addressr/blob/a4b76a5b445f3448048cca716b0919675d4c681d/client/elasticsearch.js#L155

```javascript
> `${undefined}`
'undefined'
```

And even when you pass empty ELASTIC_USERNAME/ELASTIC_PASSWORD envs

https://github.com/mountain-pass/addressr/blob/370c5e8f465cac63ae2052d4a85740ce389c2c60/client/elasticsearch.js#L10-L11

```javascript
> `${'' || undefined}`
'undefined'
```