### PR TITLE
Allow ES client to connect to managed clusters

### DIFF
--- a/client/elasticsearch.js
+++ b/client/elasticsearch.js
@@ -170,8 +170,11 @@ export async function esConnect (
         // eslint-disable-next-line no-constant-condition
         while (true) {
           try {
+            const node = ELASTIC_USERNAME ? 
+              `${ELASTIC_PROTOCOL}://${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}@${eshost}:${esport}` :
+              `${ELASTIC_PROTOCOL}://${eshost}:${esport}`
             const esClientOptions = {
-              node: `${ELASTIC_PROTOCOL}://${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}@${eshost}:${esport}`
+              node
               // ...(ELASTIC_USERNAME &&
               //   ELASTIC_PASSWORD && {
               //     cloud: {


### PR DESCRIPTION
Depending on Elasticsearch security settings the current implementation can't `ping` the cluster. Especially true for managed ES.

This bugfix allows data to be written to such clusters. (Tested on real managed cluster.)