### PR TITLE
fix(validation): last number validation

### DIFF
--- a/api/swagger-2.yaml
+++ b/api/swagger-2.yaml
@@ -397,7 +397,7 @@ definitions:
                 example: RMB
                 maxLength: 3
               number:
-                type: string
+                type: integer
                 example: '20114'
                 maxLength: 6
               suffix:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -411,7 +411,7 @@ definitions:
                 example: RMB
                 maxLength: 3
               number:
-                type: string
+                type: integer
                 example: '20114'
                 maxLength: 6
               suffix:


### PR DESCRIPTION
This PR updates the validation of last street number to be an integer rather than string.  The value is cast as an integer during import.

Resolves issue (e.g. `/addresses/GANSW715538283`) where requesting address detail for amalgamated addresses will return a schema validation failed error:

```json
{
    "code": "SCHEMA_VALIDATION_FAILED",
    "failedValidation": true,
    "originalResponse": {
        "...": "..."
    },
    "message": "Response validation failed: failed schema validation",
    "errors": [
        {
            "code": "INVALID_TYPE",
            "message": "Expected type string but found type integer",
            "path": [
                "structured",
                "number",
                "last",
                "number"
            ]
        }
    ]
}
```